### PR TITLE
Show PHP errors during tests and add more test cases

### DIFF
--- a/tests/tests.php
+++ b/tests/tests.php
@@ -8,6 +8,10 @@ Author: fluffy, http://beesbuzz.biz/
 
  */
 
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+define('DEBUG', true);
+
 ?><!DOCTYPE html>
 <html><head><title>tests</title><style>
 .pass { background: #7f7; }

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -76,6 +76,7 @@ test("/path/to/file", "other-file", "/path/to/other-file");
 # Anchors are too
 test("http://beesbuzz.biz/test/foo#anchor", "bar", "http://beesbuzz.biz/test/bar");
 test("http://beesbuzz.biz/test/foo", "bar#anchor", "http://beesbuzz.biz/test/bar#anchor");
+test("http://beesbuzz.biz", "#anchor", "http://beesbuzz.biz#anchor");
 
 # Mixing non-relative and relative url
 test("http://beesbuzz.biz/foo/bar", "javascript:void(0)", "javascript:void(0)");
@@ -83,6 +84,16 @@ test("http://beesbuzz.biz/foo/bar", "javascript:void(0)", "javascript:void(0)");
 # Sanity checks
 test("http://beesbuzz.biz/foo/bar", false, "http://beesbuzz.biz/foo/bar");
 test(false, "http://beesbuzz.biz/foo/bar", "http://beesbuzz.biz/foo/bar");
+
+# URL already valid (various kinds), base may vary
+test("https://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz");
+test("https://beesbuzz.biz/", "https://beesbuzz.biz", "https://beesbuzz.biz");
+test("https://beesbuzz.biz/", "https://beesbuzz.biz/", "https://beesbuzz.biz/");
+test("https://beesbuzz.biz/", "https://beesbuzz.biz/#test", "https://beesbuzz.biz/#test");
+
+# Same server, different scheme, URL already valid
+test("http://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz");
+test("https://beesbuzz.biz", "http://beesbuzz.biz", "http://beesbuzz.biz");
 
 ?>
 </body></html>


### PR DESCRIPTION
This PR enables PHP error reporting for all tests. This is very helpful for identifying silent issues. It also adds a few test cases that could fail:

![image](https://user-images.githubusercontent.com/5776685/43482466-0c83bfd2-9509-11e8-84ea-05d04c4e7132.png)

I'll PR a solution for these errors separately