### PR TITLE
Fix parameter checks

### DIFF
--- a/src/urljoin.php
+++ b/src/urljoin.php
@@ -39,31 +39,33 @@ function urljoin($base, $rel) {
 		$merged['path'] = $dir . '/' . $prel['path'];
 	}
 
-	// Get the path components, and remove the initial empty one
-	$pathParts = explode('/', $merged['path']);
-	array_shift($pathParts);
+	if(array_key_exists('path', $merged)) {
+		// Get the path components, and remove the initial empty one
+		$pathParts = explode('/', $merged['path']);
+		array_shift($pathParts);
 
-	$path = [];
-	$prevPart = '';
-	foreach ($pathParts as $part) {
-		if ($part == '..' && count($path) > 0) {
-			// Cancel out the parent directory (if there's a parent to cancel)
-			$parent = array_pop($path);
-			// But if it was also a parent directory, leave it in
-			if ($parent == '..') {
-				array_push($path, $parent);
+		$path = [];
+		$prevPart = '';
+		foreach ($pathParts as $part) {
+			if ($part == '..' && count($path) > 0) {
+				// Cancel out the parent directory (if there's a parent to cancel)
+				$parent = array_pop($path);
+				// But if it was also a parent directory, leave it in
+				if ($parent == '..') {
+					array_push($path, $parent);
+					array_push($path, $part);
+				}
+			} else if ($prevPart != '' || ($part != '.' && $part != '')) {
+				// Don't include empty or current-directory components
+				if ($part == '.') {
+					$part = '';
+				}
 				array_push($path, $part);
 			}
-		} else if ($prevPart != '' || ($part != '.' && $part != '')) {
-			// Don't include empty or current-directory components
-			if ($part == '.') {
-				$part = '';
-			}
-			array_push($path, $part);
+			$prevPart = $part;
 		}
-		$prevPart = $part;
+		$merged['path'] = '/' . implode('/', $path);
 	}
-	$merged['path'] = '/' . implode('/', $path);
 
 	$ret = '';
 	if (isset($merged['scheme'])) {

--- a/src/urljoin.php
+++ b/src/urljoin.php
@@ -33,7 +33,7 @@ function urljoin($base, $rel) {
 	}
 
 	$merged = array_merge($pbase, $prel);
-	if ($prel['path'][0] != '/') {
+	if (array_key_exists('path', $prel) && array_key_exists('path', $pbase) && substr($prel['path'], 0, 1) != '/') {
 		// Relative path
 		$dir = preg_replace('@/[^/]*$@', '', $pbase['path']);
 		$merged['path'] = $dir . '/' . $prel['path'];

--- a/src/urljoin.php
+++ b/src/urljoin.php
@@ -26,6 +26,10 @@ function urljoin($base, $rel) {
 	$pbase = parse_url($base);
 	$prel = parse_url($rel);
 
+	if (array_key_exists('path', $pbase) && $pbase['path'] === '/') {
+		unset($pbase['path']);
+	}
+
 	if (isset($prel['scheme'])) {
 		if ($prel['scheme'] != $pbase['scheme'] || in_array($prel['scheme'], $uses_relative) == false) {
 			return $rel;


### PR DESCRIPTION
This PR fixes a few issues reported by tests implemented in #7. Most issues were related to accessing array keys that didn't exist. Find details in the commit logs.

Lines 46-71 are reported as changed, but the only thing that changed is the level of indentation (due to Lines 45 + 71).

