### PR TITLE
Fix handling of relative paths

### DIFF
--- a/src/urljoin.php
+++ b/src/urljoin.php
@@ -37,10 +37,24 @@ function urljoin($base, $rel) {
 	}
 
 	$merged = array_merge($pbase, $prel);
-	if (array_key_exists('path', $prel) && array_key_exists('path', $pbase) && substr($prel['path'], 0, 1) != '/') {
-		// Relative path
-		$dir = preg_replace('@/[^/]*$@', '', $pbase['path']);
-		$merged['path'] = $dir . '/' . $prel['path'];
+	
+	// Handle relative paths: 
+	//   'path/to/file.ext'
+	// './path/to/file.ext'
+	if (array_key_exists('path', $prel) && substr($prel['path'], 0, 1) != '/') {
+
+		// Normalize: './path/to/file.ext' => 'path/to/file.ext'
+		if (substr($prel['path'], 0, 2) === './') {
+			$prel['path'] = substr($prel['path'], 2);
+		}
+
+		if (array_key_exists('path', $pbase)) {
+			$dir = preg_replace('@/[^/]*$@', '', $pbase['path']);
+			$merged['path'] = $dir . '/' . $prel['path'];
+		} else {
+			$merged['path'] = '/' . $prel['path'];
+		}
+
 	}
 
 	if(array_key_exists('path', $merged)) {

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -47,6 +47,11 @@ function test($base, $url, $expected) {
 
 # A file in the same directory
 test("http://beesbuzz.biz/foo/bar", "test.jpg", "http://beesbuzz.biz/foo/test.jpg");
+# A file in a subdirectory
+test("http://beesbuzz.biz/foo/bar", "images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg");
+test("http://beesbuzz.biz/foo/bar", "./images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg");
+test("http://beesbuzz.biz/foo/bar/", "images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg");
+test("http://beesbuzz.biz/foo/bar/", "./images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg");
 # A file in the root directory
 test("http://beesbuzz.biz/foo/bar", "/test.jpg", "http://beesbuzz.biz/test.jpg");
 # A file in the parent directory


### PR DESCRIPTION
e6070f5 introduced a bug that prevented relative path from working
correctly. This commit fixes the bug and adds tests for relative
paths:

  'path/to/file.ext'
'./path/to/file.ext'