### PR TITLE
Add python version of tests script

### DIFF
--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,0 +1,124 @@
+[
+	{
+		"_comment": "A file in the same directory",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", "test.jpg", "http://beesbuzz.biz/foo/test.jpg"]
+		]
+	},
+	{
+		"_comment": "A file in a subdirectory",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", "images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg"],
+			["http://beesbuzz.biz/foo/bar", "./images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg"],
+			["http://beesbuzz.biz/foo/bar/", "images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg"],
+			["http://beesbuzz.biz/foo/bar/", "./images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg"]
+		]
+	},
+	{
+		"_comment": "A file in the root directory",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", "/test.jpg", "http://beesbuzz.biz/test.jpg"]
+		]
+	},
+	{
+		"_comment": "A file in the parent directory",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar/baz", "../test.jpg", "http://beesbuzz.biz/foo/test.jpg"]
+		]
+	},
+	{
+		"_comment": "A file more directories up than there are directories to escape",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar/baz/quux", "../../../../../test.jpg", "http://beesbuzz.biz/../../test.jpg"]
+		]
+	},
+	{
+		"_comment": "The current directory itself",
+		"cases": [
+			["http://beesbuzz.biz/foo/", ".", "http://beesbuzz.biz/foo/"],
+			["http://beesbuzz.biz/foo/", "./", "http://beesbuzz.biz/foo/"],
+			["http://beesbuzz.biz/foo", ".", "http://beesbuzz.biz/"],
+			["http://beesbuzz.biz/foo", "./", "http://beesbuzz.biz/"]
+		]
+	},
+	{
+		"_comment": "Different server, same scheme",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", "//sockpuppet.us/test.jpg", "http://sockpuppet.us/test.jpg"],
+			["https://beesbuzz.biz/foo/bar", "//sockpuppet.us/test.jpg", "https://sockpuppet.us/test.jpg"]
+		]
+	},
+	{
+		"_comment": "Ensure queries work right",
+		"cases": [
+			["https://beesbuzz.biz/foo/bar.cgi?hello=goodbye", "moo.cgi?yes=no", "https://beesbuzz.biz/foo/moo.cgi?yes=no"],
+			["http://beesbuzz.biz/foo/?qwer=poiu", "bar", "http://beesbuzz.biz/foo/bar"],
+			["http://beesbuzz.biz/foo/", "bar?qwer=poiu", "http://beesbuzz.biz/foo/bar?qwer=poiu"]
+		]
+	},
+	{
+		"_comment": "Users and passwords should transfer for relative links",
+		"cases": [
+			["http://fluffy:poopbutt@beesbuzz.biz/foo/bar", ".", "http://fluffy:poopbutt@beesbuzz.biz/foo/"],
+			["http://fluffy:poopbutt@beesbuzz.biz/foo/bar", "/test/url", "http://fluffy:poopbutt@beesbuzz.biz/test/url"],
+			["http://spambot@beesbuzz.biz/foo/bar", "/test/url", "http://spambot@beesbuzz.biz/test/url"]
+		]
+	},
+	{
+		"_comment": "But shouldn't transfer to other servers",
+		"cases": [
+			["https://fluffy:poopbutt@beesbuzz.biz/foo/bar", "//sockpuppet.us/test/url", "https://sockpuppet.us/test/url"]
+		]
+	},
+	{
+		"_comment": "Port specifiers",
+		"cases": [
+			["https://beesbuzz.biz:8000/foo/bar", "//sockpuppet.us/test/url", "https://sockpuppet.us/test/url"],
+			["https://beesbuzz.biz:8000/foo/bar", "/test/url", "https://beesbuzz.biz:8000/test/url"]
+		]
+	},
+	{
+		"_comment": "File paths are fiddly",
+		"cases": [
+			["file:///path/to/file", "other-file", "file:///path/to/other-file"],
+			["/path/to/file", "other-file", "/path/to/other-file"]
+		]
+	},
+	{
+		"_comment": "Anchors are too",
+		"cases": [
+			["http://beesbuzz.biz/test/foo#anchor", "bar", "http://beesbuzz.biz/test/bar"],
+			["http://beesbuzz.biz/test/foo", "bar#anchor", "http://beesbuzz.biz/test/bar#anchor"],
+			["http://beesbuzz.biz", "#anchor", "http://beesbuzz.biz#anchor"]
+		]
+	},
+	{
+		"_comment": "Mixing non-relative and relative url",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", "javascript:void(0)", "javascript:void(0)"]
+		]
+	},
+	{
+		"_comment": "Sanity checks",
+		"cases": [
+			["http://beesbuzz.biz/foo/bar", false, "http://beesbuzz.biz/foo/bar"],
+			[false, "http://beesbuzz.biz/foo/bar", "http://beesbuzz.biz/foo/bar"]
+		]
+	},
+	{
+		"_comment": "URL already valid (various kinds), base may vary",
+		"cases": [
+			["https://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz"],
+			["https://beesbuzz.biz/", "https://beesbuzz.biz", "https://beesbuzz.biz"],
+			["https://beesbuzz.biz/", "https://beesbuzz.biz/", "https://beesbuzz.biz/"],
+			["https://beesbuzz.biz/", "https://beesbuzz.biz/#test", "https://beesbuzz.biz/#test"]
+		]
+	},
+	{
+		"_comment": "Same server, different scheme, URL already valid",
+		"cases": [
+			["http://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz"],
+			["https://beesbuzz.biz", "http://beesbuzz.biz", "http://beesbuzz.biz"]
+		]
+	}
+]

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -45,72 +45,11 @@ function test($base, $url, $expected) {
 	echo '</tr>';
 }
 
-# A file in the same directory
-test("http://beesbuzz.biz/foo/bar", "test.jpg", "http://beesbuzz.biz/foo/test.jpg");
-# A file in a subdirectory
-test("http://beesbuzz.biz/foo/bar", "images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg");
-test("http://beesbuzz.biz/foo/bar", "./images/test.jpg", "http://beesbuzz.biz/foo/images/test.jpg");
-test("http://beesbuzz.biz/foo/bar/", "images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg");
-test("http://beesbuzz.biz/foo/bar/", "./images/test.jpg", "http://beesbuzz.biz/foo/bar/images/test.jpg");
-# A file in the root directory
-test("http://beesbuzz.biz/foo/bar", "/test.jpg", "http://beesbuzz.biz/test.jpg");
-# A file in the parent directory
-test("http://beesbuzz.biz/foo/bar/baz", "../test.jpg", "http://beesbuzz.biz/foo/test.jpg");
-# A file more directories up than there are directories to escape
-test("http://beesbuzz.biz/foo/bar/baz/quux", "../../../../../test.jpg", "http://beesbuzz.biz/../../test.jpg");
-
-# The current directory itself
-test("http://beesbuzz.biz/foo/", ".", "http://beesbuzz.biz/foo/");
-test("http://beesbuzz.biz/foo/", "./", "http://beesbuzz.biz/foo/");
-test("http://beesbuzz.biz/foo", ".", "http://beesbuzz.biz/");
-test("http://beesbuzz.biz/foo", "./", "http://beesbuzz.biz/");
-
-# Different server, same scheme
-test("http://beesbuzz.biz/foo/bar", "//sockpuppet.us/test.jpg", "http://sockpuppet.us/test.jpg");
-test("https://beesbuzz.biz/foo/bar", "//sockpuppet.us/test.jpg", "https://sockpuppet.us/test.jpg");
-
-# Ensure queries work right
-test("https://beesbuzz.biz/foo/bar.cgi?hello=goodbye", "moo.cgi?yes=no", "https://beesbuzz.biz/foo/moo.cgi?yes=no");
-test("http://beesbuzz.biz/foo/?qwer=poiu", "bar", "http://beesbuzz.biz/foo/bar");
-test("http://beesbuzz.biz/foo/", "bar?qwer=poiu", "http://beesbuzz.biz/foo/bar?qwer=poiu");
-
-# Users and passwords should transfer for relative links
-test("http://fluffy:poopbutt@beesbuzz.biz/foo/bar", ".", "http://fluffy:poopbutt@beesbuzz.biz/foo/");
-test("http://fluffy:poopbutt@beesbuzz.biz/foo/bar", "/test/url", "http://fluffy:poopbutt@beesbuzz.biz/test/url");
-test("http://spambot@beesbuzz.biz/foo/bar", "/test/url", "http://spambot@beesbuzz.biz/test/url");
-
-# But shouldn't transfer to other servers
-test("https://fluffy:poopbutt@beesbuzz.biz/foo/bar", "//sockpuppet.us/test/url", "https://sockpuppet.us/test/url");
-
-# Port specifiers
-test("https://beesbuzz.biz:8000/foo/bar", "//sockpuppet.us/test/url", "https://sockpuppet.us/test/url");
-test("https://beesbuzz.biz:8000/foo/bar", "/test/url", "https://beesbuzz.biz:8000/test/url");
-
-# File paths are fiddly
-test("file:///path/to/file", "other-file", "file:///path/to/other-file");
-test("/path/to/file", "other-file", "/path/to/other-file");
-
-# Anchors are too
-test("http://beesbuzz.biz/test/foo#anchor", "bar", "http://beesbuzz.biz/test/bar");
-test("http://beesbuzz.biz/test/foo", "bar#anchor", "http://beesbuzz.biz/test/bar#anchor");
-test("http://beesbuzz.biz", "#anchor", "http://beesbuzz.biz#anchor");
-
-# Mixing non-relative and relative url
-test("http://beesbuzz.biz/foo/bar", "javascript:void(0)", "javascript:void(0)");
-
-# Sanity checks
-test("http://beesbuzz.biz/foo/bar", false, "http://beesbuzz.biz/foo/bar");
-test(false, "http://beesbuzz.biz/foo/bar", "http://beesbuzz.biz/foo/bar");
-
-# URL already valid (various kinds), base may vary
-test("https://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz");
-test("https://beesbuzz.biz/", "https://beesbuzz.biz", "https://beesbuzz.biz");
-test("https://beesbuzz.biz/", "https://beesbuzz.biz/", "https://beesbuzz.biz/");
-test("https://beesbuzz.biz/", "https://beesbuzz.biz/#test", "https://beesbuzz.biz/#test");
-
-# Same server, different scheme, URL already valid
-test("http://beesbuzz.biz", "https://beesbuzz.biz", "https://beesbuzz.biz");
-test("https://beesbuzz.biz", "http://beesbuzz.biz", "http://beesbuzz.biz");
+foreach(json_decode(file_get_contents(__DIR__ . '/cases.json'), true) as $item) {
+	foreach($item['cases'] as $case) {
+		test($case[0], $case[1], $case[2]);
+	}
+}
 
 ?>
 </table></body></html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import json
+import os
+import sys
+
+if sys.version_info[0] == 2:
+	from urlparse import urljoin
+else:
+	print("python v2 is expected")
+	sys.exit(1)
+
+__DIR__ = os.path.dirname(os.path.realpath(__file__))
+
+bad_cases = []
+return_code = 0
+overall_cases_count = 0
+
+f = open(__DIR__ + "/cases.json", "r")
+
+for item in json.loads(f.read()):
+	for case in item['cases']:
+		overall_cases_count += 1
+		if urljoin(case[0], case[1]) != case[2]:
+			bad_cases.append([case[0], case[1], urljoin(case[0], case[1]), case[2]])
+
+f.close()
+
+if len(bad_cases) == 0:
+	print("OK. {} case(s) read".format(overall_cases_count))
+else:
+	return_code = 1
+	for case in bad_cases:
+		print("{} + {} = {} (expected {})".format(case[0], case[1], case[2], case[3]))
+
+sys.exit(return_code)


### PR DESCRIPTION
This makes sure that php's port of urljoin matches oringal one from python2.
Unfortunately python3's urljoin differs from python2, so forcing script to able to run only on python2.

Running on python3 returns this (assuming to use `from urllib.parse import urlparse`):
```
http://beesbuzz.biz/foo/bar/baz/quux + ../../../../../test.jpg = http://beesbuzz.biz/test.jpg (expected http://beesbuzz.biz/../../test.jpg)
```